### PR TITLE
Fixed sending single messages to kafka in collector

### DIFF
--- a/collector/Cargo.toml
+++ b/collector/Cargo.toml
@@ -37,6 +37,9 @@ criterion = "0.3.6"
 mockall = "0.11.2"
 tokio-test = "0.4.2"
 
+[profile.release]
+debug = 1
+
 [lib]
 name = "lib"
 path = "src/lib.rs"

--- a/collector/src/application_state.rs
+++ b/collector/src/application_state.rs
@@ -93,7 +93,7 @@ impl ApplicationState {
             .expect("unable to initialize importer");
 
         // make a shared channel for common data
-        let (tx, mut rx) = mpsc::channel::<Vec<u8>>(20);
+        let (tx, mut rx) = mpsc::channel::<Vec<u8>>(1024);
 
         let tx1 = tx.clone();
 

--- a/collector/src/exporters/errors.rs
+++ b/collector/src/exporters/errors.rs
@@ -1,12 +1,12 @@
-use rdkafka::{error::KafkaError, message::OwnedMessage};
+use rdkafka::error::KafkaError;
 
 #[derive(Debug)]
 pub enum ExporterError {
-    KafkaErr((KafkaError, OwnedMessage)),
+    KafkaErr(KafkaError),
 }
 
-impl From<(KafkaError, OwnedMessage)> for ExporterError {
-    fn from(error: (KafkaError, OwnedMessage)) -> ExporterError {
+impl From<KafkaError> for ExporterError {
+    fn from(error: KafkaError) -> ExporterError {
         ExporterError::KafkaErr(error)
     }
 }


### PR DESCRIPTION
FutureProducer enforces flushing buffer after every send, so I changed to ThreadedProducer, which allows to send for every n messages. It tremendously improves performance of the collector